### PR TITLE
Fieldlines: better  doc + better base options for cmp with 'mirror'

### DIFF
--- a/examples/batch_mode/02-bulb_fieldlines1.py
+++ b/examples/batch_mode/02-bulb_fieldlines1.py
@@ -63,7 +63,7 @@ def plot(plot_dir):
     pp.add_postproc("cont_iter", Continuous_iter_pp())
     pp.add_postproc("interior", Raw_pp("stop_reason", func="x != 1."))
     pp.add_postproc("fieldlines",
-                Fieldlines_pp(n_iter=1, swirl=0., damping_ratio=1.0))
+                Fieldlines_pp(n_iter=4, swirl=0., damping_ratio=1.0))
 
     plotter = fs.Fractal_plotter(pp)   
     plotter.add_layer(Bool_layer("interior", output=False))

--- a/examples/batch_mode/02-bulb_fieldlines1.py
+++ b/examples/batch_mode/02-bulb_fieldlines1.py
@@ -63,7 +63,7 @@ def plot(plot_dir):
     pp.add_postproc("cont_iter", Continuous_iter_pp())
     pp.add_postproc("interior", Raw_pp("stop_reason", func="x != 1."))
     pp.add_postproc("fieldlines",
-                Fieldlines_pp(n_iter=4, swirl=1., damping_ratio=0.1))
+                Fieldlines_pp(n_iter=1, swirl=0., damping_ratio=1.0))
 
     plotter = fs.Fractal_plotter(pp)   
     plotter.add_layer(Bool_layer("interior", output=False))

--- a/examples/batch_mode/03-bulb_fieldlines2.py
+++ b/examples/batch_mode/03-bulb_fieldlines2.py
@@ -39,7 +39,7 @@ def plot(plot_dir):
     y = 0.96946619217
     dx = 0.6947111395902539
     nx = 2400
-    calc_name="mandelbrot"
+    calc_name="argon"
     colormap = fscolors.cmap_register["argon"]
 
     # Run the calculation
@@ -61,7 +61,7 @@ def plot(plot_dir):
     pp.add_postproc("cont_iter", Continuous_iter_pp())
     pp.add_postproc("interior", Raw_pp("stop_reason", func="x != 1."))
     pp.add_postproc("fieldlines",
-                Fieldlines_pp(n_iter=4, swirl=1., damping_ratio=0.9))
+                Fieldlines_pp(n_iter=4, swirl=0., damping_ratio=1.0))
 
     plotter = fs.Fractal_plotter(pp)   
     plotter.add_layer(Bool_layer("interior", output=False))
@@ -69,7 +69,7 @@ def plot(plot_dir):
             "cont_iter",
             func="np.log(x)",
             colormap=colormap,
-            probes_z=[2., 6.],
+            probes_z=[-1.5, 1.5],
             probes_kind="absolute",
             output=True
     ))
@@ -78,7 +78,7 @@ def plot(plot_dir):
 
     # This is the line where we indicate that coloring is a combination of
     # "Continuous iteration" and "fieldines values"
-    plotter["cont_iter"].set_twin_field(plotter["fieldlines"], 0.3)
+    plotter["cont_iter"].set_twin_field(plotter["fieldlines"], 0.2)
     plotter.plot()
 
 

--- a/examples/batch_mode/03-bulb_fieldlines2.py
+++ b/examples/batch_mode/03-bulb_fieldlines2.py
@@ -39,7 +39,7 @@ def plot(plot_dir):
     y = 0.96946619217
     dx = 0.6947111395902539
     nx = 2400
-    calc_name="argon"
+    calc_name="mandelbrot"
     colormap = fscolors.cmap_register["argon"]
 
     # Run the calculation

--- a/install_from_local-static.sh
+++ b/install_from_local-static.sh
@@ -6,7 +6,7 @@
 # python3 -m pip install --prefix=/home/geoffroy/.local/lib/python3.8/site-packages --force-reinstall --no-deps --editable .
 
 # "Normal" installation
-python3 -m pip install --user --force-reinstall --no-deps ./dist/fractalshades-0.4.x.tar.gz
+python3 -m pip install --user --force-reinstall --no-deps ./dist/fractalshades-0.4.0b0.tar.gz
 #fractalshades-0.3.0-py3-none-any.whl
 
 # upload to test repository

--- a/src/fractalshades/__init__.py
+++ b/src/fractalshades/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __author__ = "G. Billotey"
 __license__ = "MIT"
-__version__ = "0.4.x"
+__version__ = "0.4.0.b0"
 
 from .settings import get_figures, close
 from .utils import zoom_options, calc_options, interactive_options

--- a/src/fractalshades/postproc.py
+++ b/src/fractalshades/postproc.py
@@ -330,10 +330,17 @@ class Continuous_iter_pp(Postproc):
     
 
 class Fieldlines_pp(Postproc):
-    def __init__(self, n_iter=5, swirl=1., damping_ratio=0.1):
+    def __init__(self, n_iter=5, swirl=0., damping_ratio=0.25):
         """
         Return a continuous orbit-averaged angular value, allowing to reveal
         fieldlines
+        
+        Fieldlines approximate the external rays which are very important
+        in the study of the Mandelbrot set and more generally in
+        holomorphic dynamics. Implementation based on [#f2]_.
+
+        .. [#f2] *On Smooth Fractal Coloring Techniques*,
+                  **Jussi Härkönenen**, Abo University, 2007
 
         Parameters
         ==========
@@ -363,13 +370,13 @@ class Fieldlines_pp(Postproc):
     def __getitem__(self, chunk_slice):
         """  Returns 
         """
-        nu_frac = self.ensure_context("nu_frac") #- 2
+        nu_frac = self.ensure_context("nu_frac")
         potential_dic = self.ensure_context("potential_dic")
         d = potential_dic["d"]
         a_d = potential_dic["a_d"]
 
         (chunk_mask, Z, U, stop_reason, stop_iter, complex_dic, int_dic,
-            termination_dic) = self.raw_data# (chunk_slice)
+            termination_dic) = self.raw_data
         zn = Z[complex_dic["zn"], :]
 
         if potential_dic["kind"] == "infinity":
@@ -383,15 +390,15 @@ class Fieldlines_pp(Postproc):
             swirl_fl = self.swirl
             t = [np.angle(z_norm)]
             val = np.zeros_like(t)
-            # Convergence of a geometric serie at 10 percent
+            # Geometric serie, last term being damping_ratio * first term
             damping = self.damping_ratio ** (1. / (n_iter_fl + 1))
             di = 1.
             rg = np.random.default_rng(0)
-            dphi_arr = rg.random(n_iter_fl) * swirl_fl * np.pi * 0.25
+            dphi_arr = rg.random(n_iter_fl) * swirl_fl * np.pi
             for i in range(1, n_iter_fl + 1):
                 t += [d * t[i - 1]] # chained list
                 dphi = dphi_arr[i-1]
-                angle = np.sin(t[i-1] + dphi) + (
+                angle = 1. + np.sin(t[i-1] + dphi) + (
                       k_alpha + k_beta * d**nu_frac) * (
                       np.sin(t[i] + dphi) - np.sin(t[i-1] + dphi))
                 val += di * angle

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -267,10 +267,10 @@ class Test_layers(unittest.TestCase):
                 layer_name,
                 func="np.log(x)",
                 colormap=self.colormap,
-                probes_z=[0., 0.4],
+                probes_z=[0.0, 0.4], #[0.065, 0.465],
                 probes_kind="relative",
                 output=True))
-        plotter.add_layer(Virtual_layer("fieldlines", func=None, output=False))
+        plotter.add_layer(Virtual_layer("fieldlines", func="x-2.2", output=False))
 
         plotter[layer_name].set_mask(plotter["interior"],
                                      mask_color=(0., 0., 0.))
@@ -281,7 +281,7 @@ class Test_layers(unittest.TestCase):
         self.check_current_layer()
 
 
-    test_config.no_stdout
+    @test_config.no_stdout
     def test_overlay1(self):
         # lets do a second calculation for instance the interior points
         layer_name = "overlay1"
@@ -329,7 +329,7 @@ class Test_layers(unittest.TestCase):
                 probes_kind="relative",
                 output=True))
         
-        plotter.add_layer(Virtual_layer("fieldlines", func=None, output=False))
+        plotter.add_layer(Virtual_layer("fieldlines", func="x-2.2", output=False))
         plotter[layer_name].set_twin_field(plotter["fieldlines"], 0.1)
 
         plotter.add_layer(Normal_map_layer("attr_map", max_slope=90, output=True))
@@ -417,7 +417,7 @@ class Test_layers(unittest.TestCase):
     @test_config.no_stdout
     def test_curve(self):
         for (i, curve) in enumerate([
-                lambda x: x,
+                lambda x: x, # , + 1.,
                 lambda x: 0.5 + (x - 0.5) * 0.2,
                 lambda x: 0.5 + 0.5 * np.sign(x - 0.5) * np.abs((x - 0.5) * 2.)**2,
                 lambda x: 0.5 + 0.5 * np.sign(x - 0.5) * np.abs((x - 0.5) * 2.)**0.5,
@@ -428,7 +428,7 @@ class Test_layers(unittest.TestCase):
                 pp.add_postproc(layer_name, Continuous_iter_pp())
                 pp.add_postproc("interior", Raw_pp("stop_reason", func="x != 1."))
                 pp.add_postproc("fieldlines",
-                        Fieldlines_pp(n_iter=5, swirl=0.7, damping_ratio=0.1))
+                        Fieldlines_pp(n_iter=5, swirl=0.25*0.7, damping_ratio=0.1))
 
                 plotter = fs.Fractal_plotter(pp)   
                 plotter.add_layer(Bool_layer("interior", output=False))
@@ -436,7 +436,7 @@ class Test_layers(unittest.TestCase):
                         layer_name,
                         func="np.log(x)",
                         colormap=self.colormap,
-                        probes_z=[0., 0.4],
+                        probes_z=[0.0, 0.4], #[0., 0.4],
                         probes_kind="relative",
                         output=True))
                 plotter.add_layer(Grey_layer("fieldlines",
@@ -453,7 +453,7 @@ class Test_layers(unittest.TestCase):
 
                 plotter.plot()
                 self.layer = plotter[layer_name]
-                self.check_current_layer()
+                self.check_current_layer(0.04)
 
 
     def check_current_layer(self, err_max=0.01):
@@ -475,5 +475,5 @@ if __name__ == "__main__":
         runner.run(test_config.suite([Test_layers]))
     else:
         suite = unittest.TestSuite()
-        suite.addTest(Test_layers("test_overlay1"))
+        suite.addTest(Test_layers("test_twin"))
         runner.run(suite)

--- a/tests/test_perturbation.py
+++ b/tests/test_perturbation.py
@@ -249,7 +249,7 @@ class Test_Perturbation_mandelbrot(unittest.TestCase):
 
         plotter = fs.Fractal_plotter(pp)   
         plotter.add_layer(Bool_layer("interior", output=False))
-        plotter.add_layer(Virtual_layer("fieldlines", func=None, output=False))
+        plotter.add_layer(Virtual_layer("fieldlines", func="x-2.", output=False))
         plotter.add_layer(Normal_map_layer("DEM_map", max_slope=45, output=True))
         # min: 11.806656837463379
         # max: 11.809494972229004
@@ -514,5 +514,5 @@ if __name__ == "__main__":
         runner.run(test_config.suite([Test_Perturbation_mandelbrot]))
     else:
         suite = unittest.TestSuite()
-        suite.addTest(Test_Perturbation_mandelbrot("test_glitch_dyn"))
+        suite.addTest(Test_Perturbation_mandelbrot("test_M2_E213"))
         runner.run(suite)


### PR DESCRIPTION
Quote reference for fieldlines
fieldlines > 0. by default, to avoid wrapping when we are a one cmap end with option = "mirror"