### PR TITLE
Use @overload instead of @generated_jit

### DIFF
--- a/tests/test_numba_xr.py
+++ b/tests/test_numba_xr.py
@@ -795,10 +795,9 @@ class Test_numba_xr(unittest.TestCase):
 
         
 
-
 if __name__ == "__main__":
     import test_config
-    full_test = False
+    full_test = True
     runner = unittest.TextTestRunner(verbosity=2)
     if full_test:
         runner.run(test_config.suite([


### PR DESCRIPTION
Workaround for

NumbaDeprecationWarning: numba.generated_jit is deprecated. Please see the documentation at: https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-generated-jit for more information and advice on a suitable replacement.