### PR TITLE
oldest-supported-numpy is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "Cython",
-    "numpy>=2.2.0",
+    "numpy>=2.0,<3",
     "gmpy2" # @ git+https://github.com/aleaxit/gmpy.git"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
See:
https://numpy.org/doc/stable/dev/depending_on_numpy.html https://github.com/scipy/oldest-supported-numpy

with NumPy 2.0, it is now necessary to use >=2.0 at build time for packages that want to support both NumPy 1.xx and 2.0.

X ref #161 